### PR TITLE
Update dependencies

### DIFF
--- a/nodejs/aws-serverless/examples/api/package.json
+++ b/nodejs/aws-serverless/examples/api/package.json
@@ -7,8 +7,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0-rc1",
-        "@pulumi/pulumi": "^0.14.0-rc1"
+        "@pulumi/aws": "^0.14.0",
+        "@pulumi/pulumi": "^0.14.0"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-serverless/examples/api/yarn.lock
+++ b/nodejs/aws-serverless/examples/api/yarn.lock
@@ -45,18 +45,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.0-rc1.tgz#212eb02e415c3e45ec920b79851d92e53e02f8c1"
+"@pulumi/aws@^0.14.0":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1.tgz#d0db840cf394f516737f4e2f0cfd450c1fa87ba9"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.0"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.0-rc1.tgz#cf559d4e5f6b06e1918635990e0daa281b8e404f"
+"@pulumi/pulumi@^0.14.0":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.2.tgz#6b3454138526e7682f3ff8fe96acdfe093f43715"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/nodejs/aws-serverless/examples/bucket/package.json
+++ b/nodejs/aws-serverless/examples/bucket/package.json
@@ -7,8 +7,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0-rc1",
-        "@pulumi/pulumi": "^0.14.0-rc1"
+        "@pulumi/aws": "^0.14.0",
+        "@pulumi/pulumi": "^0.14.0"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-serverless/examples/bucket/yarn.lock
+++ b/nodejs/aws-serverless/examples/bucket/yarn.lock
@@ -45,18 +45,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.0-rc1.tgz#212eb02e415c3e45ec920b79851d92e53e02f8c1"
+"@pulumi/aws@^0.14.0":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1.tgz#d0db840cf394f516737f4e2f0cfd450c1fa87ba9"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.0"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.0-rc1.tgz#cf559d4e5f6b06e1918635990e0daa281b8e404f"
+"@pulumi/pulumi@^0.14.0":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.2.tgz#6b3454138526e7682f3ff8fe96acdfe093f43715"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/nodejs/aws-serverless/examples/cloudwatch/package.json
+++ b/nodejs/aws-serverless/examples/cloudwatch/package.json
@@ -7,8 +7,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0-rc1",
-        "@pulumi/pulumi": "^0.14.0-rc1",
+        "@pulumi/aws": "^0.14.0",
+        "@pulumi/pulumi": "^0.14.0",
         "node-fetch": "^1.7.3"
     },
     "devDependencies": {

--- a/nodejs/aws-serverless/examples/cloudwatch/yarn.lock
+++ b/nodejs/aws-serverless/examples/cloudwatch/yarn.lock
@@ -45,18 +45,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.0-rc1.tgz#212eb02e415c3e45ec920b79851d92e53e02f8c1"
+"@pulumi/aws@^0.14.0":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1.tgz#d0db840cf394f516737f4e2f0cfd450c1fa87ba9"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.0"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.0-rc1.tgz#cf559d4e5f6b06e1918635990e0daa281b8e404f"
+"@pulumi/pulumi@^0.14.0":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.2.tgz#6b3454138526e7682f3ff8fe96acdfe093f43715"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/nodejs/aws-serverless/examples/queue/package.json
+++ b/nodejs/aws-serverless/examples/queue/package.json
@@ -7,8 +7,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.1-dev-1530315247-g2b541a9",
-        "@pulumi/pulumi": "^0.14.0-rc1"
+        "@pulumi/aws": "^0.14.0",
+        "@pulumi/pulumi": "^0.14.0"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-serverless/examples/queue/yarn.lock
+++ b/nodejs/aws-serverless/examples/queue/yarn.lock
@@ -45,18 +45,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.1-dev-1530315247-g2b541a9":
-  version "0.14.1-dev-1530553082-gd537d2c"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1-dev-1530553082-gd537d2c.tgz#008c1587f3b925da1e70eda969790be384cdbeb4"
+"@pulumi/aws@^0.14.0":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1.tgz#d0db840cf394f516737f4e2f0cfd450c1fa87ba9"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.0"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.1.tgz#7cddcd958d42f16635afe455acf700d22f27a4e4"
+"@pulumi/pulumi@^0.14.0":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.2.tgz#6b3454138526e7682f3ff8fe96acdfe093f43715"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/nodejs/aws-serverless/examples/topic/package.json
+++ b/nodejs/aws-serverless/examples/topic/package.json
@@ -7,8 +7,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/aws": "^0.14.0-rc1",
-        "@pulumi/pulumi": "^0.14.0-rc1",
+        "@pulumi/aws": "^0.14.0",
+        "@pulumi/pulumi": "^0.14.0",
         "node-fetch": "^1.7.3"
     },
     "devDependencies": {

--- a/nodejs/aws-serverless/examples/topic/yarn.lock
+++ b/nodejs/aws-serverless/examples/topic/yarn.lock
@@ -45,18 +45,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.0-rc1.tgz#212eb02e415c3e45ec920b79851d92e53e02f8c1"
+"@pulumi/aws@^0.14.0":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1.tgz#d0db840cf394f516737f4e2f0cfd450c1fa87ba9"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.0"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.0-rc1.tgz#cf559d4e5f6b06e1918635990e0daa281b8e404f"
+"@pulumi/pulumi@^0.14.0":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.2.tgz#6b3454138526e7682f3ff8fe96acdfe093f43715"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"

--- a/nodejs/aws-serverless/package.json
+++ b/nodejs/aws-serverless/package.json
@@ -11,8 +11,8 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-aws-serverless",
     "dependencies": {
-        "@pulumi/aws": "^0.14.1-dev-1530315247-g2b541a9",
-        "@pulumi/pulumi": "^0.14.0-rc1"
+        "@pulumi/aws": "^0.14.1",
+        "@pulumi/pulumi": "^0.14.0"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-serverless/yarn.lock
+++ b/nodejs/aws-serverless/yarn.lock
@@ -45,18 +45,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.14.1-dev-1530315247-g2b541a9":
-  version "0.14.1-dev-1530553082-gd537d2c"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1-dev-1530553082-gd537d2c.tgz#008c1587f3b925da1e70eda969790be384cdbeb4"
+"@pulumi/aws@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.14.1.tgz#d0db840cf394f516737f4e2f0cfd450c1fa87ba9"
   dependencies:
-    "@pulumi/pulumi" "^0.14.0-rc1"
+    "@pulumi/pulumi" "^0.14.0"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.14.0-rc1":
-  version "0.14.0-rc1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.0-rc1.tgz#cf559d4e5f6b06e1918635990e0daa281b8e404f"
+"@pulumi/pulumi@^0.14.0":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.14.2.tgz#6b3454138526e7682f3ff8fe96acdfe093f43715"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"


### PR DESCRIPTION
In preperation for cutting 0.14.1 of this package, consume 0.14.1 of pulumi-aws which has the new SQS triggering stuff.

I keep the constraints in the tests to be ^0.14.0 since their explicit dependency on aws did not need the newer package, this resolves to `0.14.1` however.