### PR TITLE
Allow route handlers to be invoked by API Gateway console.

### DIFF
--- a/nodejs/aws-serverless/api.ts
+++ b/nodejs/aws-serverless/api.ts
@@ -165,7 +165,11 @@ export class API extends pulumi.ComponentResource {
                             action: "lambda:invokeFunction",
                             function: lambda,
                             principal: "apigateway.amazonaws.com",
-                            sourceArn: this.deployment.executionArn.apply(arn => arn + stageName + "/" + method + path),
+                            // We give permission for this function to be invoked by any stage at the given method and
+                            // path on the API. We allow any stage instead of encoding the one known stage that will be
+                            // deployed by Pulumi because the API Gateway console "Test" feature invokes the route
+                            // handler with the fake stage `test-invoke-stage`.
+                            sourceArn: this.deployment.executionArn.apply(arn => arn + "*/" + method + path),
                         }, { parent: this });
                     }
                 }


### PR DESCRIPTION
This change broadens permission to invoke a Lambda used as an API route handler to any stage of the API, not just the one managed by Pulumi.  This is required to support use of the API Gateway console's "Test" functionality.

Fixes #29.