### PR TITLE
Update licenses in package.json files.

### DIFF
--- a/nodejs/aws-serverless/examples/api/package.json
+++ b/nodejs/aws-serverless/examples/api/package.json
@@ -1,6 +1,7 @@
 {
     "name": "api",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/nodejs/aws-serverless/examples/bucket/package.json
+++ b/nodejs/aws-serverless/examples/bucket/package.json
@@ -1,6 +1,7 @@
 {
     "name": "bucket",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/nodejs/aws-serverless/examples/cloudwatch/package.json
+++ b/nodejs/aws-serverless/examples/cloudwatch/package.json
@@ -1,6 +1,7 @@
 {
     "name": "cloudwatch",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/nodejs/aws-serverless/examples/queue/package.json
+++ b/nodejs/aws-serverless/examples/queue/package.json
@@ -1,6 +1,7 @@
 {
     "name": "queue",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/nodejs/aws-serverless/examples/topic/package.json
+++ b/nodejs/aws-serverless/examples/topic/package.json
@@ -1,6 +1,7 @@
 {
     "name": "topic",
     "version": "0.1",
+    "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",
     "scripts": {

--- a/nodejs/aws-serverless/package.json
+++ b/nodejs/aws-serverless/package.json
@@ -2,7 +2,7 @@
     "name": "@pulumi/aws-serverless",
     "version": "${VERSION}",
     "description": "Pulumi Amazon Web Services (AWS) Serverless Components.",
-    "license": "Apache 2.0",
+    "license": "Apache-2.0",
     "keywords": [
         "pulumi",
         "aws",


### PR DESCRIPTION
This gets rid of all the:

```
warning package.json: License should be a valid SPDX license expression
warning @pulumi/aws-infra@${VERSION}: License should be a valid SPDX license expression
```

messages that show up while building.