### PR TITLE
Make test package versions valid semvers

### DIFF
--- a/nodejs/aws-serverless/examples/api/package.json
+++ b/nodejs/aws-serverless/examples/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "api",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/nodejs/aws-serverless/examples/bucket/package.json
+++ b/nodejs/aws-serverless/examples/bucket/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bucket",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/nodejs/aws-serverless/examples/cloudwatch/package.json
+++ b/nodejs/aws-serverless/examples/cloudwatch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "cloudwatch",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/nodejs/aws-serverless/examples/queue/package.json
+++ b/nodejs/aws-serverless/examples/queue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "queue",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",

--- a/nodejs/aws-serverless/examples/topic/package.json
+++ b/nodejs/aws-serverless/examples/topic/package.json
@@ -1,6 +1,6 @@
 {
     "name": "topic",
-    "version": "0.1",
+    "version": "0.0.1",
     "license": "Apache-2.0",
     "main": "bin/index.js",
     "typings": "bin/index.d.ts",


### PR DESCRIPTION
NPM and some other packages (including read-package-json that
@pulumi/pulumi) uses require the version field to be a valid
semver. So ensure ours are.