### PR TITLE
Move to the core functionality that is was pushed down into @pulumi/aws.

### DIFF
--- a/nodejs/aws-serverless/bucket.ts
+++ b/nodejs/aws-serverless/bucket.ts
@@ -12,209 +12,50 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as aws from "@pulumi/aws";
-import { lambda, s3 } from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import { createLambdaFunction, Handler } from "./function";
-import { EventSubscription } from "./subscription";
 
-/**
- * Arguments to help customize a notification subscription for a bucket.
- */
-export interface SimpleBucketSubscriptionArgs {
-    /**
-     * An optional prefix or suffix to filter down notifications.  See
-     * aws.s3.BucketNotification.lambdaFunctions for more details.
-     */
-    filterPrefix?: string;
-    filterSuffix?: string;
-}
+import { s3 } from "@pulumi/aws";
 
-export interface BucketSubscriptionArgs extends SimpleBucketSubscriptionArgs {
-    /**
-     * Events to subscribe to. For example: "s3:ObjectCreated:*".  Cannot be empty.
-     */
-    events: string[];
-}
+/** @deprecated Use [s3.CommonBucketSubscriptionArgs] instead. */
+export type SimpleBucketSubscriptionArgs = s3.CommonBucketSubscriptionArgs;
+/** @deprecated Use [s3.BucketEventSubscriptionArgs] instead. */
+export type BucketSubscriptionArgs = s3.BucketEventSubscriptionArgs;
+/** @deprecated Use [s3.ObjectCreatedSubscriptionArgs] instead. */
+export type BucketPutArgs = s3.ObjectCreatedSubscriptionArgs;
+/** @deprecated Use [s3.ObjectRemovedSubscriptionArgs] instead. */
+export type BucketDeleteArgs = s3.ObjectRemovedSubscriptionArgs;
+/** @deprecated Use [s3.BucketEvent] instead. */
+export type BucketEvent = s3.BucketEvent;
+/** @deprecated Use [s3.BucketRecord] instead. */
+export type BucketRecord = s3.BucketRecord;
+/** @deprecated Use [s3.BucketEventHandler] instead. */
+export type BucketEventHandler = s3.BucketEventHandler;
 
-/**
- * Arguments to specifically control a subscription to 'put' notifications on a bucket.
- * Specifically, 'events' should not be provided as they will be assumed to be "s3:ObjectCreated:*".
- * If different events are desired, the 'subscribe' function should be used instead.
- */
-export type BucketPutArgs = SimpleBucketSubscriptionArgs;
-
-/**
- * Arguments to specifically control a subscription to 'delete' notifications on a bucket.
- * Specifically, 'events' should not be provided as they will be assumed to be "s3:ObjectRemoved:*".
- * If different events are desired, the 'subscribe' function should be used instead.
- */
-export type BucketDeleteArgs = SimpleBucketSubscriptionArgs;
-
-// See https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html.
-export interface BucketEvent {
-    Records?: BucketRecord[];
-}
-
-export interface BucketRecord {
-    eventVersion: string;
-    eventSource: string;
-    awsRegion: string;
-    eventTime: string;
-    eventName: string;
-    userIdentity: {
-        principalId: string;
-    };
-    requestParameters: {
-        sourceIPAddress: string;
-    };
-    responseElements: {
-        "x-amz-request-id": string;
-        "x-amz-id-2": string;
-    };
-    s3: {
-        s3SchemaVersion: string;
-        configurationId: string;
-        bucket: {
-            name: string;
-            ownerIdentity: {
-                principalId: string;
-            },
-            arn: string;
-        };
-        object: {
-            key: string;
-            size: number;
-            eTag: string;
-            versionId?: string;
-            sequencer: string;
-        };
-    };
-}
-
-
-// tslint:disable:max-line-length
-export type BucketEventHandler = Handler<BucketEvent, void>;
-
+/** @deprecated Use [s3.Bucket.onObjectCreated] instead. */
 export function onPut(
     name: string, bucket: s3.Bucket, handler: BucketEventHandler,
     args?: BucketPutArgs, opts?: pulumi.ResourceOptions): BucketEventSubscription {
 
-    args = args || {};
-
-    const argsCopy = {
-        ...args,
-        events: ["s3:ObjectCreated:*"],
-    };
-
-    return onEvent(name + "-put", bucket, handler, argsCopy, opts);
+    return bucket.onObjectCreated(name, handler, args, opts);
 }
 
+/** @deprecated Use [s3.Bucket.onObjectRemoved] instead. */
 export function onDelete(
     name: string, bucket: s3.Bucket, handler: BucketEventHandler,
     args?: BucketDeleteArgs, opts?: pulumi.ResourceOptions): BucketEventSubscription {
 
-    args = args || {};
-
-    const argsCopy = {
-        ...args,
-        events: ["s3:ObjectRemoved:*"],
-    };
-
-    return onEvent(name + "-delete", bucket, handler, argsCopy, opts);
+    return bucket.onObjectRemoved(name, handler, args, opts);
 }
 
-const defaultComputePolicies = [
-    aws.iam.AWSLambdaFullAccess,                 // Provides wide access to "serverless" services (Dynamo, S3, etc.)
-    aws.iam.AmazonEC2ContainerServiceFullAccess, // Required for lambda compute to be able to run Tasks
-];
-
-/**
- * Creates a new subscription to the given bucket using the lambda provided, along with optional
- * options to control the behavior of the subscription.  This function should be used when full
- * control over the subscription is wanted, and other helpers (like onPut/onDelete) are not
- * sufficient.
- */
+/** @deprecated Use [s3.Bucket.onEvent] instead. */
 export function onEvent(
     name: string, bucket: s3.Bucket, handler: BucketEventHandler,
     args: BucketSubscriptionArgs, opts?: pulumi.ResourceOptions): BucketEventSubscription {
 
-    const func = createLambdaFunction(name + "-bucket-subscription", handler, opts);
-    return new BucketEventSubscription(name, bucket, func, args, opts);
+    return bucket.onEvent(name, handler, args, opts);
 }
 
-interface SubscriptionInfo {
-    name: string;
-    events: string[];
-    filterPrefix?: string;
-    filterSuffix?: string;
-    lambdaFunctionArn: pulumi.Output<string>;
-    permission: aws.lambda.Permission;
-}
-
-let bucketSubscriptionInfos = new Map<s3.Bucket, SubscriptionInfo[]>();
-
-/**
- * A component corresponding to a single underlying aws.s3.BucketNotification created for a bucket.
- * Note: due to the AWS requirement that all notifications for a bucket be defined at once, the
- * actual aws.s3.BucketNotification instances will only be created once the pulumi program runs to
- * completion and all subscriptions have been heard about.
- */
-export class BucketEventSubscription extends EventSubscription {
-    public constructor(
-        name: string, bucket: s3.Bucket, func: lambda.Function,
-        args: BucketSubscriptionArgs, opts?: pulumi.ResourceOptions) {
-
-        super("aws-serverless:bucket:BucketEventSubscription", name, func, { bucket: bucket }, opts);
-
-        const permission = new aws.lambda.Permission(name, {
-            function: func,
-            action: "lambda:InvokeFunction",
-            principal: "s3.amazonaws.com",
-            sourceArn: bucket.id.apply(bucketName => `arn:aws:s3:::${bucketName}`),
-        }, { parent: this });
-
-        this.permission = permission;
-
-        // We must create only a single BucketNotification per Bucket per AWS API limitations.  See
-        // https://github.com/terraform-providers/terraform-provider-aws/issues/1715.  So we push
-        // the subscription information here, and then actually create the BucketNotification if
-        // needed on process `beforeExit`.
-        let subscriptions = bucketSubscriptionInfos.get(bucket);
-        if (!subscriptions) {
-            subscriptions = [];
-            bucketSubscriptionInfos.set(bucket, subscriptions);
-        }
-
-        subscriptions.push({
-            name: name,
-            events: args.events,
-            filterPrefix: args.filterPrefix,
-            filterSuffix: args.filterSuffix,
-            lambdaFunctionArn: func.arn,
-            permission: permission,
-        });
-    }
-}
-
-process.on("beforeExit", () => {
-    const copy = bucketSubscriptionInfos;
-
-    // Since we are generating more work on the event loop, we will casue `beforeExit` to be invoked again.
-    // Make sure to clear out eh pending subscrpitions array so that we don't try to apply them again.
-
-    bucketSubscriptionInfos = new Map();
-
-    for (const [bucket, subscriptions] of copy) {
-        const permissions = subscriptions.map(s => s.permission);
-        const _ = new aws.s3.BucketNotification(subscriptions[0].name, {
-            bucket: bucket.id,
-            lambdaFunctions: subscriptions.map(subscription => ({
-                events: subscription.events,
-                filterPrefix: subscription.filterPrefix,
-                filterSuffix: subscription.filterSuffix,
-                lambdaFunctionArn: subscription.lambdaFunctionArn,
-            })),
-        }, { parent: bucket, dependsOn: permissions });
-    }
-});
+/** @deprecated Use [s3.BucketEventSubscription] instead. */
+export const BucketEventSubscription = s3.BucketEventSubscription;
+/** @deprecated Use [s3.BucketEventSubscription] instead. */
+export type BucketEventSubscription = s3.BucketEventSubscription;

--- a/nodejs/aws-serverless/cloudwatch.ts
+++ b/nodejs/aws-serverless/cloudwatch.ts
@@ -12,68 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as aws from "@pulumi/aws";
-import { cloudwatch, lambda } from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import { createLambdaFunction, Handler } from "./function";
-import { EventSubscription } from "./subscription";
 
-export interface CloudwatchEventArgs {
-}
+import { cloudwatch } from "@pulumi/aws";
 
-export interface CloudwatchEvent {
-    account: string;
-    region: string;
-    detail: any;
-    "detail-type": string;
-    source: string;
-    time: string;
-    id: string;
-    resources: string[];
-}
-
-export type CloudwatchEventHandler = Handler<CloudwatchEvent, void>;
-
+/** @deprecated Use [cloudwatch.EventRuleEventSubscriptionArgs] instead */
+export type CloudwatchEventArgs = cloudwatch.EventRuleEventSubscriptionArgs;
+/** @deprecated Use [cloudwatch.EventRuleEvent] instead */
+export type CloudwatchEvent = cloudwatch.EventRuleEvent;
+/** @deprecated Use [cloudwatch.EventRuleEventHandler] instead */
+export type CloudwatchEventHandler = cloudwatch.EventRuleEventHandler;
+/** @deprecated Use [cloudwatch.onSubscribe] or [cloudwatch.EventRule.onEvent] instead */
 export function onEvent(name: string, schedule: string, handler: CloudwatchEventHandler, args?: CloudwatchEventArgs, opts?: pulumi.ResourceOptions): CloudwatchEventSubscription;
 export function onEvent(name: string, rule: cloudwatch.EventRule, handler: CloudwatchEventHandler, args?: CloudwatchEventArgs, opts?: pulumi.ResourceOptions): CloudwatchEventSubscription;
 export function onEvent(
     name: string, scheduleOrRule: string | cloudwatch.EventRule,
     handler: CloudwatchEventHandler, args?: CloudwatchEventArgs, opts?: pulumi.ResourceOptions): CloudwatchEventSubscription {
 
-    args = args || {};
-    const func = createLambdaFunction(name + "-cloudwatch-subscription", handler, opts);
-    return new CloudwatchEventSubscription(name, scheduleOrRule, func, args, opts);
-}
-
-export class CloudwatchEventSubscription extends EventSubscription {
-    public readonly eventRule: cloudwatch.EventRule;
-    public readonly target: cloudwatch.EventTarget;
-
-    public constructor(
-        name: string, scheduleOrRule: string | cloudwatch.EventRule, func: lambda.Function,
-        args: CloudwatchEventArgs, opts?: pulumi.ResourceOptions) {
-
-        super("aws-serverless:cloudwatch:CloudwatchEventSubscription", name, func, { }, opts);
-
-        if (typeof scheduleOrRule === "string") {
-            this.eventRule = new cloudwatch.EventRule(name, {
-                scheduleExpression: scheduleOrRule,
-            }, { parent: this });
-        } else {
-            this.eventRule = scheduleOrRule;
-        }
-
-        this.target = new aws.cloudwatch.EventTarget(name, {
-            rule: this.eventRule.name,
-            arn: this.func.arn,
-            targetId: name,
-        }, { parent: this });
-
-        this.permission = new aws.lambda.Permission(name, {
-            action: "lambda:invokeFunction",
-            function: this.func,
-            principal: "events.amazonaws.com",
-            sourceArn: this.eventRule.arn,
-        }, { parent: this });
+    if (typeof scheduleOrRule === "string") {
+        return cloudwatch.onSchedule(name, scheduleOrRule, handler, args, opts);
     }
+
+    return scheduleOrRule.onEvent(name, handler, args, opts);
 }
+
+/** @deprecated Use [cloudwatch.EventRuleEventSubscription] instead */
+// tslint:disable-next-line:variable-name
+export const CloudwatchEventSubscription = cloudwatch.EventRuleEventSubscription;
+/** @deprecated Use [cloudwatch.EventRuleEventSubscription] instead */
+export type CloudwatchEventSubscription = cloudwatch.EventRuleEventSubscription;

--- a/nodejs/aws-serverless/examples/api/package.json
+++ b/nodejs/aws-serverless/examples/api/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
-        "@pulumi/aws": "^0.15.1"
+        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/aws": "^0.15.2-dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-serverless/examples/api/yarn.lock
+++ b/nodejs/aws-serverless/examples/api/yarn.lock
@@ -45,18 +45,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@pulumi/aws@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.1.tgz#6c313b2ad082a956683c5cb0652e98ed41e581e7"
+"@pulumi/aws@^0.15.2-dev":
+  version "0.15.2-dev-1537576411-gb9a83b6"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.2-dev-1537576411-gb9a83b6.tgz#f6a24f8609112741d6ab755c4c30080b16d34f49"
   dependencies:
-    "@pulumi/pulumi" "^0.15.1"
+    "@pulumi/pulumi" "^0.15.4-dev"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.15.1":
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.1.tgz#1b94077ec0bfb8fef868d6aa66643d7f726c0678"
+"@pulumi/pulumi@^0.15.4-dev":
+  version "0.15.4-dev-1537556338-g2b610ce5"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537556338-g2b610ce5.tgz#e2e0dcf7d3c4ac761cad1e5577fb28fd294fdfa5"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -75,13 +75,17 @@
   dependencies:
     aws-sdk "*"
 
-"@types/long@^3.0.32":
-  version "3.0.32"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
+"@types/long@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
 
-"@types/node@^8.0.27", "@types/node@^8.9.4":
-  version "8.10.21"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.21.tgz#12b3f2359b27aa05a45d886c8ba1eb8d1a77e285"
+"@types/node@^10.1.0":
+  version "10.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.10.2.tgz#2a55b8d66f6945efc5da38489774e551248aa169"
+
+"@types/node@^8.0.27":
+  version "8.10.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.30.tgz#2c82cbed5f79d72280c131d2acffa88fbd8dd353"
 
 abbrev@1:
   version "1.1.1"
@@ -122,8 +126,8 @@ ascli@~1:
     optjs "~3.2.2"
 
 aws-sdk@*:
-  version "2.273.1"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.273.1.tgz#69398a128090c71f0c66480b5c32054773e4c03f"
+  version "2.320.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.320.0.tgz#8089976be31e170771652f62b6796aab5dd9d7b4"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -133,7 +137,7 @@ aws-sdk@*:
     sax "1.2.1"
     url "0.10.3"
     uuid "3.1.0"
-    xml2js "0.4.17"
+    xml2js "0.4.19"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -156,7 +160,7 @@ buffer-from@^1.0.0, buffer-from@^1.1.0:
 
 buffer@4.9.1:
   version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  resolved "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -181,8 +185,8 @@ camelcase@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
 chownr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
 
 cliui@^3.0.3:
   version "3.2.0"
@@ -277,8 +281,8 @@ gauge@~2.7.3:
     wide-align "^1.1.0"
 
 glob@^7.0.5, glob@^7.1.1:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -288,16 +292,16 @@ glob@^7.0.5, glob@^7.1.1:
     path-is-absolute "^1.0.0"
 
 google-protobuf@^3.5.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.0.tgz#e2bafb00c20a8734174d8f89e0a842709e2ceed0"
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.6.1.tgz#7ef58e2bea137a93cdaf5cfd5afa5f6abdd92025"
 
 graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
 grpc@^1.12.2:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.13.0.tgz#cbf884fa5e072edecb15ff019483db74b361e2c6"
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.15.1.tgz#046263d9b0c440c8e36fece03e227cb3afe28514"
   dependencies:
     lodash "^4.17.5"
     nan "^2.0.0"
@@ -313,8 +317,8 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
 
 iconv-lite@^0.4.4:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
@@ -353,7 +357,7 @@ invert-kv@^1.0.0:
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  resolved "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
 
@@ -385,9 +389,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lodash@^4.0.0, lodash@^4.17.5:
-  version "4.17.10"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
+lodash@^4.17.5:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 long@^4.0.0:
   version "4.0.0"
@@ -409,15 +413,15 @@ minimatch@^3.0.4:
 
 minimist@0.0.8:
   version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
 minimist@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+  resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
 minipass@^2.2.1, minipass@^2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.3.tgz#a7dcc8b7b833f5d368759cce544dccb55f50f233"
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.4.tgz#4768d7605ed6194d6d576169b9e12ef71e9d9957"
   dependencies:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
@@ -430,7 +434,7 @@ minizlib@^1.1.0:
 
 mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
 
@@ -439,12 +443,12 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
 nan@^2.0.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.0.tgz#574e360e4d954ab16966ec102c0c049fd961a099"
 
 needle@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.1.tgz#b5e325bd3aae8c2678902fa296f729455d1d3a7d"
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.3.tgz#c1b04da378cd634d8befe2de965dc2cfb0fd65ca"
   dependencies:
     debug "^2.1.2"
     iconv-lite "^0.4.4"
@@ -482,12 +486,12 @@ normalize-package-data@^2.0.0, normalize-package-data@^2.4.0:
     validate-npm-package-license "^3.0.1"
 
 npm-bundled@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
 
 npm-packlist@^1.1.6:
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.10.tgz#1039db9e985727e464df066f4cf0ab6ef85c398a"
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.1.11.tgz#84e8c683cbe7867d34b1d357d893ce29e28a02de"
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
@@ -525,7 +529,7 @@ os-homedir@^1.0.0:
 
 os-locale@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
+  resolved "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz#20f9f17ae29ed345e8bde583b13d2009803c14d9"
   dependencies:
     lcid "^1.0.0"
 
@@ -545,8 +549,8 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
 path-parse@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
 
 process-nextick-args@~2.0.0:
   version "2.0.0"
@@ -562,8 +566,8 @@ protobufjs@^5.0.3:
     yargs "^3.10.0"
 
 protobufjs@^6.8.6:
-  version "6.8.6"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.6.tgz#ce3cf4fff9625b62966c455fc4c15e4331a11ca2"
+  version "6.8.8"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.8.8.tgz#c8b4f1282fd7a90e6f5b109ed11c84af82908e7c"
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -575,8 +579,8 @@ protobufjs@^6.8.6:
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.0"
-    "@types/long" "^3.0.32"
-    "@types/node" "^8.9.4"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
     long "^4.0.0"
 
 punycode@1.3.2:
@@ -619,7 +623,7 @@ read-package-tree@^5.2.1:
 
 readable-stream@^2.0.6:
   version "2.3.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
+  resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -664,15 +668,15 @@ safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
 
 sax@1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  resolved "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
 
 sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -726,8 +730,8 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz#e2a303236cac54b04031fa7a5a79c7e701df852f"
 
 string-width@^1.0.1:
   version "1.0.2"
@@ -767,8 +771,8 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 tar@^4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.4.tgz#ec8409fae9f665a4355cc3b4087d0820232bb8cd"
+  version "4.4.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
   dependencies:
     chownr "^1.0.1"
     fs-minipass "^1.2.5"
@@ -791,11 +795,7 @@ ts-node@^7.0.0:
     source-map-support "^0.5.6"
     yn "^2.0.0"
 
-typescript@^2.8.3:
-  version "2.9.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
-
-typescript@^3.0.0:
+typescript@^3.0.0, typescript@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
@@ -815,8 +815,8 @@ uuid@3.1.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
 validate-npm-package-license@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
@@ -833,7 +833,7 @@ window-size@^0.1.4:
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
+  resolved "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
@@ -842,18 +842,16 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
 
-xml2js@0.4.17:
-  version "0.4.17"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   dependencies:
     sax ">=0.6.0"
-    xmlbuilder "^4.1.0"
+    xmlbuilder "~9.0.1"
 
-xmlbuilder@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
-  dependencies:
-    lodash "^4.0.0"
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
 
 y18n@^3.2.0:
   version "3.2.1"
@@ -865,7 +863,7 @@ yallist@^3.0.0, yallist@^3.0.2:
 
 yargs@^3.10.0:
   version "3.32.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
+  resolved "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz#03088e9ebf9e756b69751611d2a5ef591482c995"
   dependencies:
     camelcase "^2.0.1"
     cliui "^3.0.3"

--- a/nodejs/aws-serverless/examples/bucket/package.json
+++ b/nodejs/aws-serverless/examples/bucket/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
-        "@pulumi/aws": "^0.15.1"
+        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/aws": "^0.15.2-dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-serverless/examples/cloudwatch/package.json
+++ b/nodejs/aws-serverless/examples/cloudwatch/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
-        "@pulumi/aws": "^0.15.1",
+        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/aws": "^0.15.2-dev",
         "node-fetch": "^1.7.3"
     },
     "devDependencies": {

--- a/nodejs/aws-serverless/examples/queue/package.json
+++ b/nodejs/aws-serverless/examples/queue/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
-        "@pulumi/aws": "^0.15.1"
+        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/aws": "^0.15.2-dev"
     },
     "devDependencies": {
         "@types/aws-sdk": "^2.7.0",

--- a/nodejs/aws-serverless/examples/topic/package.json
+++ b/nodejs/aws-serverless/examples/topic/package.json
@@ -8,8 +8,8 @@
         "build": "tsc"
     },
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
-        "@pulumi/aws": "^0.15.1",
+        "@pulumi/pulumi": "^0.15.4-dev",
+        "@pulumi/aws": "^0.15.2-dev",
         "node-fetch": "^1.7.3"
     },
     "devDependencies": {

--- a/nodejs/aws-serverless/function.ts
+++ b/nodejs/aws-serverless/function.ts
@@ -12,29 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as aws from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
+
+import * as aws from "@pulumi/aws";
 import { ResourceOptions } from "@pulumi/pulumi";
 
-/**
- * A synchronous or asynchronous function that can be converted into an AWS lambda.  Async callbacks
- * are only supported with an AWS lambda runtime of 8.10 or higher.  On those runtimes a Promise can
- * be returned, 'callback' parameter can be ignored, and AWS will appropriately handle things. For
- * AWS lambda pre-8.10, a synchronous function must be provided.  The synchronous function should
- * return nothing, and should instead invoke 'callback' when complete.
- */
-export type Callback<E, R> = (event: E, context: aws.serverless.Context, callback: (error: any, result: R) => void) => Promise<R> | void;
+/** @deprecated Use [lambda.Callback] instead. */
+export type Callback<E, R> = aws.lambda.Callback<E, R>;
 
-/**
- * Handler represents the appropriate type for functions that can take either an AWS lambda function
- * instance, or a JS function object that will then be used to create the AWS lambda function.
- */
-export type Handler<E, R> = Callback<E, R> | aws.lambda.Function;
+/** @deprecated Use [lambda.EventHandler] instead. */
+export type Handler<E, R> = aws.lambda.EventHandler<E, R>;
 
 const defaultComputePolicies = [
     aws.iam.AWSLambdaFullAccess,                 // Provides wide access to "serverless" services (Dynamo, S3, etc.)
 ];
 
+/** @deprecated Use [lambda.createCallbackFunction] instead. */
 export function createLambdaFunction<E, R>(
     name: string, handler: Handler<E, R>, opts?: ResourceOptions,
     functionOptions?: aws.serverless.FunctionOptions): aws.lambda.Function {

--- a/nodejs/aws-serverless/package.json
+++ b/nodejs/aws-serverless/package.json
@@ -11,7 +11,7 @@
     "homepage": "https://pulumi.io",
     "repository": "https://github.com/pulumi/pulumi-aws-serverless",
     "dependencies": {
-        "@pulumi/pulumi": "^0.15.3-dev",
+        "@pulumi/pulumi": "^0.15.4-dev",
         "@pulumi/aws": "^0.15.2-dev"
     },
     "devDependencies": {

--- a/nodejs/aws-serverless/queue.ts
+++ b/nodejs/aws-serverless/queue.ts
@@ -12,89 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as aws from "@pulumi/aws";
-import { iam, lambda, sqs } from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import { createLambdaFunction, Handler } from "./function";
-import { EventSubscription } from "./subscription";
 
-export interface QueueEvent {
-    Records: QueueRecord[];
-}
+import { sqs } from "@pulumi/aws";
 
-export interface QueueRecord {
-    messageId: string;
-    receiptHandle: string;
-    body: string;
-    attributes: {
-        ApproximateReceiveCount: string;
-        SentTimestamp: string;
-        SenderId: string;
-        ApproximateFirstReceiveTimestamp: string;
-    };
-    messageAttributes: Record<string, any>;
-    md5OfBody: string;
-    eventSource: string;
-    eventSourceARN: string;
-    awsRegion: string;
-}
+/** @deprecated use [sqs.QueueEvent] instead */
+export type QueueEvent = sqs.QueueEvent;
+/** @deprecated use [sqs.QueueRecord] instead */
+export type QueueRecord = sqs.QueueRecord;
+/** @deprecated use [sqs.QueueEventHandler] instead */
+export type QueueEventHandler = sqs.QueueEventHandler;
+/** @deprecated use [sqs.QueueSubscriptionArgs] instead */
+export type QueueSubscriptionArgs = sqs.QueueEventSubscriptionArgs;
 
-export type QueueEventHandler = Handler<QueueEvent, void>;
-
-/**
- * Arguments to control the sqs subscription.
- */
-export type QueueSubscriptionArgs = {
-    /**
-     * The largest number of records that AWS Lambda will retrieve. The maximum batch size supported
-     * by Amazon Simple Queue Service is up to 10 queue messages per batch. The default setting is
-     * 10.
-     *
-     * See https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html for more details.
-     */
-    batchSize?: number;
- };
-
-/**
- * Creates a new subscription to the given queue using the lambda provided, along with optional
- * options to control the behavior of the subscription.
- */
+/** @deprecated use [sqs.Queue.onEvent] instead */
 export function subscribe(
-    name: string, topic: sqs.Queue, handler: QueueEventHandler,
+    name: string, queue: sqs.Queue, handler: QueueEventHandler,
     args?: QueueSubscriptionArgs, opts?: pulumi.ResourceOptions): QueueEventSubscription {
 
-    args = args || {};
-    const func = createLambdaFunction(name + "-queue-subscription", handler, opts, {
-        policies: [aws.iam.AWSLambdaFullAccess, iam.AmazonSQSFullAccess],
-    });
-    return new QueueEventSubscription(name, topic, func, args, opts);
+    return queue.onEvent(name, handler, args, opts);
 }
 
-export class QueueEventSubscription extends EventSubscription {
-    /**
-     * The underlying sns object created for the subscription.
-     */
-    public readonly eventSourceMapping: lambda.EventSourceMapping;
-
-    public constructor(
-        name: string, queue: sqs.Queue, func: lambda.Function,
-        args: QueueSubscriptionArgs, opts?: pulumi.ResourceOptions) {
-
-        super("aws-serverless:queue:QueueEventSubscription", name, func, { queue: queue }, opts);
-
-        args = args || {};
-        this.permission = new aws.lambda.Permission(name, {
-            action: "lambda:*",
-            function: func,
-            principal: "sqs.amazonaws.com",
-            sourceArn: queue.arn,
-        }, { parent: this });
-
-        this.eventSourceMapping = new lambda.EventSourceMapping(name, {
-            batchSize: args.batchSize,
-            enabled: true,
-            eventSourceArn: queue.arn,
-            functionName: func.name,
-        }, { parent: this });
-    }
-}
+/** @deprecated use [sqs.QueueEventSubscription] instead */
+export const QueueEventSubscription = sqs.QueueEventSubscription;
+/** @deprecated use [sqs.QueueEventSubscription] instead */
+export type QueueEventSubscription = sqs.QueueEventSubscription;

--- a/nodejs/aws-serverless/subscription.ts
+++ b/nodejs/aws-serverless/subscription.ts
@@ -15,9 +15,7 @@
 import { lambda } from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
 
-/**
- * Base type for all subscription types.
- */
+/** @deprecated Use [lambda.EventSubscription] instead */
 export class EventSubscription extends pulumi.ComponentResource {
     public permission: lambda.Permission;
     public func: lambda.Function;

--- a/nodejs/aws-serverless/topic.ts
+++ b/nodejs/aws-serverless/topic.ts
@@ -12,86 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as aws from "@pulumi/aws";
-import { lambda, sns } from "@pulumi/aws";
 import * as pulumi from "@pulumi/pulumi";
-import { createLambdaFunction, Handler } from "./function";
-import { EventSubscription } from "./subscription";
 
-export interface TopicEvent {
-    Records: TopicRecord[];
-}
+import { sns } from "@pulumi/aws";
 
-export interface TopicRecord {
-    EventVersion: string;
-    EventSubscriptionArn: string;
-    EventSource: string;
-    Sns: SNSItem;
-}
+/** @deprecated Use [sns.TopicEvent] instead */
+export type TopicEvent = sns.TopicEvent;
+/** @deprecated Use [sns.TopicRecord] instead */
+export type TopicRecord = sns.TopicRecord;
+/** @deprecated Use [sns.SNSItem] instead */
+export type SNSItem = sns.SNSItem;
+/** @deprecated Use [sns.SNSMessageAttribute] instead */
+export type SNSMessageAttribute = sns.SNSMessageAttribute;
+/** @deprecated Use [sns.TopicEventHandler] instead */
+export type TopicEventHandler = sns.TopicEventHandler;
+/** @deprecated Use [sns.TopicSubscriptionArgs] instead */
+export type TopicSubscriptionArgs = sns.TopicSubscriptionArgs;
 
-export interface SNSItem {
-    SignatureVersion: string;
-    Timestamp: string;
-    Signature: string;
-    SigningCertUrl: string;
-    MessageId: string;
-    Message: string;
-    MessageAttributes: { [key: string]: SNSMessageAttribute };
-    Type: string;
-    UnsubscribeUrl: string;
-    TopicArn: string;
-    Subject: string;
-}
-
-export interface SNSMessageAttribute {
-    Type: string;
-    Value: string;
-}
-
-export type TopicEventHandler = Handler<TopicEvent, void>;
-
-/**
- * Arguments to control the topic subscription.  Currently empty, but still defined in case of
- * future need.
- */
-export type TopicSubscriptionArgs = { };
-
-/**
- * Creates a new subscription to the given topic using the lambda provided, along with optional
- * options to control the behavior of the subscription.
- */
+/** @deprecated Use [sns.Topic.onEvent] instead */
 export function subscribe(
     name: string, topic: sns.Topic, handler: TopicEventHandler,
     args?: TopicSubscriptionArgs, opts?: pulumi.ResourceOptions): TopicEventSubscription {
 
-    args = args || {};
-    const func = createLambdaFunction(name + "-topic-subscription", handler, opts);
-    return new TopicEventSubscription(name, topic, func, args, opts);
+    return topic.onEvent(name, handler, args, opts);
 }
 
-export class TopicEventSubscription extends EventSubscription {
-    /**
-     * The underlying sns object created for the subscription.
-     */
-    public readonly subscription: sns.TopicSubscription;
-
-    public constructor(
-        name: string, topic: sns.Topic, func: lambda.Function,
-        args: TopicSubscriptionArgs, opts?: pulumi.ResourceOptions) {
-
-        super("aws-serverless:topic:TopicEventSubscription", name, func, { topic: topic }, opts);
-
-        this.permission = new aws.lambda.Permission(name, {
-            action: "lambda:invokeFunction",
-            function: func,
-            principal: "sns.amazonaws.com",
-            sourceArn: topic.id,
-        }, { parent: this });
-
-        this.subscription = new aws.sns.TopicSubscription(name, {
-            topic: topic,
-            protocol: "lambda",
-            endpoint: func.arn,
-        }, { parent: this });
-    }
-}
+/** @deprecated Use [sns.TopicEventSubscription] instead */
+export const TopicEventSubscription = sns.TopicEventSubscription;
+/** @deprecated Use [sns.TopicEventSubscription] instead */
+export type TopicEventSubscription = sns.TopicEventSubscription;

--- a/nodejs/aws-serverless/yarn.lock
+++ b/nodejs/aws-serverless/yarn.lock
@@ -54,21 +54,6 @@
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.15.3-dev":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.3.tgz#2a4ee8f1270384b722fc6b18e5f98a3fa82a5619"
-  dependencies:
-    google-protobuf "^3.5.0"
-    grpc "^1.12.2"
-    minimist "^1.2.0"
-    normalize-package-data "^2.4.0"
-    protobufjs "^6.8.6"
-    read-package-tree "^5.2.1"
-    require-from-string "^2.0.1"
-    source-map-support "^0.4.16"
-    ts-node "^7.0.0"
-    typescript "^3.0.0"
-
 "@pulumi/pulumi@^0.15.4-dev":
   version "0.15.4-dev-1537556338-g2b610ce5"
   resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537556338-g2b610ce5.tgz#e2e0dcf7d3c4ac761cad1e5577fb28fd294fdfa5"

--- a/nodejs/aws-serverless/yarn.lock
+++ b/nodejs/aws-serverless/yarn.lock
@@ -46,17 +46,17 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
 "@pulumi/aws@^0.15.2-dev":
-  version "0.15.2-dev-1536778434-ga569ebd"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.2-dev-1536778434-ga569ebd.tgz#9bbd98e332779548267b66723477ba94536b1c10"
+  version "0.15.2-dev-1537576411-gb9a83b6"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-0.15.2-dev-1537576411-gb9a83b6.tgz#f6a24f8609112741d6ab755c4c30080b16d34f49"
   dependencies:
-    "@pulumi/pulumi" "^0.15.1"
+    "@pulumi/pulumi" "^0.15.4-dev"
     builtin-modules "3.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/pulumi@^0.15.1":
-  version "0.15.2"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.2.tgz#940dfc4b7d64597674fccf58d510d4870889a9e7"
+"@pulumi/pulumi@^0.15.3-dev":
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.3.tgz#2a4ee8f1270384b722fc6b18e5f98a3fa82a5619"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -69,9 +69,9 @@
     ts-node "^7.0.0"
     typescript "^3.0.0"
 
-"@pulumi/pulumi@^0.15.3-dev":
-  version "0.15.3-dev-1536980346-gd67e0424"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.3-dev-1536980346-gd67e0424.tgz#122e3f9b00b07f320b37f04845d5866a5c973f74"
+"@pulumi/pulumi@^0.15.4-dev":
+  version "0.15.4-dev-1537556338-g2b610ce5"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-0.15.4-dev-1537556338-g2b610ce5.tgz#e2e0dcf7d3c4ac761cad1e5577fb28fd294fdfa5"
   dependencies:
     google-protobuf "^3.5.0"
     grpc "^1.12.2"
@@ -95,12 +95,12 @@
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
 
 "@types/node@^10.1.0":
-  version "10.9.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.9.4.tgz#0f4cb2dc7c1de6096055357f70179043c33e9897"
+  version "10.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.10.2.tgz#2a55b8d66f6945efc5da38489774e551248aa169"
 
 "@types/node@^8.0.26":
-  version "8.10.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.29.tgz#b3a13b58dd7b0682bf1b42022bef4a5a9718f687"
+  version "8.10.30"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.30.tgz#2c82cbed5f79d72280c131d2acffa88fbd8dd353"
 
 abbrev@1:
   version "1.1.1"
@@ -157,8 +157,8 @@ ascli@~1:
     optjs "~3.2.2"
 
 aws-sdk@*:
-  version "2.315.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.315.0.tgz#7f393162af038cbef722374444a9bc9ae1bdbbe9"
+  version "2.320.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.320.0.tgz#8089976be31e170771652f62b6796aab5dd9d7b4"
   dependencies:
     buffer "4.9.1"
     events "1.1.1"
@@ -242,8 +242,8 @@ chalk@^2.3.0:
     supports-color "^5.3.0"
 
 chownr@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.0.1.tgz#e2a75042a9551908bebd25b8523d5f9769d79181"
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
 
 cliui@^3.0.3:
   version "3.2.0"
@@ -450,7 +450,7 @@ invert-kv@^1.0.0:
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  resolved "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
   dependencies:
     builtin-modules "^1.0.0"
 


### PR DESCRIPTION
Removes code in aws-serverless that is now redundant with the code in `@pulumi/aws`.  however, removal is done in a backward compatible fashion.  All existing entrypoints just forward ot the 'aws' code.